### PR TITLE
QueueDbAdapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sergeysvrollun/rollun-callback",
+  "name": "rollun-com/rollun-callback",
   "description": "Callback",
   "minimum-stability": "stable",
   "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "rollun-com/rollun-logger": "^4.0",
     "zendframework/zend-json": "^3.1",
     "zendframework/zend-stratigility": "^3.0",
-    "zendframework/zend-diactoros": "^2.0"
+    "zendframework/zend-diactoros": "^2.0",
+    "zendframework/zend-db": "^2.10"
   },
   "require-dev": {
     "zendframework/zend-config-aggregator": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "rollun-com/rollun-callback",
+  "name": "sergeysvrollun/rollun-callback",
   "description": "Callback",
   "minimum-stability": "stable",
   "type": "library",

--- a/config/autoload/test.global.php
+++ b/config/autoload/test.global.php
@@ -80,7 +80,7 @@ return [
         ]
     ],
     DbAdapterAbstractFactory::class => [
-        'requestedServiceName1' => [
+        'testDbQueueClient' => [
                'timeInflight' => 0,
         ]
     ],
@@ -92,6 +92,10 @@ return [
         'testFileQueueClient' => [
             'name' => 'fileQueue',
             'adapter' => 'testFileQueue',
+        ],
+        'testDbQueueClient' => [
+            'name' => 'dbQueue',
+            'adapter' => 'testDbQueue',
         ],
     ],
 ];

--- a/config/autoload/test.global.php
+++ b/config/autoload/test.global.php
@@ -79,7 +79,11 @@ return [
             ],
         ]
     ],
-    DbAdapterAbstractFactory::class => [],
+    DbAdapterAbstractFactory::class => [
+        'requestedServiceName1' => [
+               'timeInflight' => 0,
+        ]
+    ],
     QueueClientAbstractFactory::class => [
         'testSqsQueueClient' => [
             'name' => 'sqsQueue',

--- a/config/autoload/test.global.php
+++ b/config/autoload/test.global.php
@@ -14,6 +14,7 @@ use rollun\callback\Callback\Multiplexer;
 use rollun\callback\Queues\Factory\FileAdapterAbstractFactory;
 use rollun\callback\Queues\Factory\QueueClientAbstractFactory;
 use rollun\callback\Queues\Factory\SqsAdapterAbstractFactory;
+use rollun\callback\Queues\Factory\DbAdapterAbstractFactory;
 
 return [
     SerializedCallbackAbstractFactory::class => [
@@ -78,6 +79,7 @@ return [
             ],
         ]
     ],
+    DbAdapterAbstractFactory::class => [],
     QueueClientAbstractFactory::class => [
         'testSqsQueueClient' => [
             'name' => 'sqsQueue',

--- a/config/autoload/test.global.php
+++ b/config/autoload/test.global.php
@@ -82,6 +82,7 @@ return [
     DbAdapterAbstractFactory::class => [
         'testDbQueue' => [
             'timeInflight' => 0,
+            'maxReceiveCount' => 1,
         ]
     ],
     QueueClientAbstractFactory::class => [

--- a/config/autoload/test.global.php
+++ b/config/autoload/test.global.php
@@ -80,8 +80,8 @@ return [
         ]
     ],
     DbAdapterAbstractFactory::class => [
-        'testDbQueueClient' => [
-               'timeInflight' => 0,
+        'testDbQueue' => [
+            'timeInflight' => 0,
         ]
     ],
     QueueClientAbstractFactory::class => [

--- a/docs/dbQueue.md
+++ b/docs/dbQueue.md
@@ -1,0 +1,46 @@
+## QueueDbAdapter
+
+`rollun\callback\Queues\Adapter\DbAdapter` - адаптер, реализующий хранение очереди сообщений в БД.
+Для работы нужен Db адаптер `Zend\Db\Adapter\Adapter`. `QueueDbAdapter` реализует интерфейсы 
+`ReputationVIP\QueueClient\Adapter\AdapterInterface` и `rollun\callback\Queues\Adapter\DeadMessagesInterface`
+Первый представляет интерфейс адаптера, который определяет где и каким образом будут храниться сообщения, 
+а второй - интерфейс для работы с мертвыми сообщениями.
+Для создания `QueueDbAdapter` существует фабрика `DbAdapterAbstractFactory`.
+
+Адаптеру для работы с клиентом очереди можна указывать параметр `timeInFlight`, который указывает на то сколько времени сообщение
+будет недоступно из очереди, если его не удалить.
+
+Также адаптеру можно передать параметр `maxReceiveCount` (`default=0`) который указывает сколько раз можно 
+взять сообщение из очереди до того как оно будет считаться мертвым. 
+Мертвые сообщения нельзя достать методом `getMessages()`, нельзя посчитать методом `getNumberMessages()`,
+метод `isEmpty()` для очереди, где есть только мертвые сообщения, вернет  `true`.
+
+Для работы с мертвыми сообщениями `QueueDbAdapter` реализует методы `getNumberDeadMessages()`, `getDeadMessages()` 
+и `deleteDeadMessages()`.
+
+Метод `getNumberDeadMessages()` возвращает количество мертвых сообщений;
+Метод `getDeadMessages()` возвращает найденые мертвые сообщения и тут же их удаляет;
+Метод `deleteDeadMessages()` удаляет указаное количество мертвых сообщений;
+
+Пример:
+
+```php
+
+$timeInFlight = 0;
+$maxReceiveCount = 1; //сообщения будут считаться мертвыми после первого считывания
+$object = new rollun\callback\Queues\Adapter\DbAdapter($container->get('db'), $timeInFlight, $maxReceiveCount);
+$object->createQueue('a');
+$object->addMessage('a', 'message1');
+$object->addMessage('a', 'message2');
+$object->addMessage('a', 'message3');
+$object->addMessage('a', 'message');
+$object->getMessages('a', 3); // три из четырех сообщений теперь "мертвые"
+sleep(1);
+echo $object->isEmpty('a'); //false - в очереди еще есть немертвые сообщения
+
+echo $object->getNumberDeadMessages('a'); // 3
+//мертвые сообщения которые содержатся в переменной $deadMessages теперь удалены из БД
+$deadMessages = $object->getDeadMessages('a', 10); 
+echo $object->getDeadMessages('a'); // array()
+    
+```

--- a/docs/dbQueue.md
+++ b/docs/dbQueue.md
@@ -7,13 +7,57 @@
 а второй - интерфейс для работы с мертвыми сообщениями.
 Для создания `QueueDbAdapter` существует фабрика `DbAdapterAbstractFactory`.
 
-Адаптеру для работы с клиентом очереди можна указывать параметр `timeInFlight`, который указывает на то сколько времени сообщение
-будет недоступно из очереди, если его не удалить.
+Адаптеру для работы с клиентом очереди можна указывать параметр `timeInFlight`, который указывает на то, 
+сколько времени сообщение будет недоступно из очереди, если его не удалить.
 
 Также адаптеру можно передать параметр `maxReceiveCount` (`default=0`) который указывает сколько раз можно 
 взять сообщение из очереди до того как оно будет считаться мертвым. 
 Мертвые сообщения нельзя достать методом `getMessages()`, нельзя посчитать методом `getNumberMessages()`,
 метод `isEmpty()` для очереди, где есть только мертвые сообщения, вернет  `true`.
+
+### Реализация интерфейса `ReputationVIP\QueueClient\Adapter\AdapterInterface`:
+
+`QueueDbAdapter` хранит каждую очередь в отдельной таблице. Имя таблицы состоит из:
+* префикса `queue_`;
+* имени очереди;
+* суффикса, в который записываются параметры очереди - `_{timeInFlight}_{maxReceiveCount}`
+
+Методы:
+
+* `listQueues($prefix = '')` - возвращает список очередей;
+* `createQueue($queueName)` - создает таблицу (если ее нет);
+* `deleteQueue($queueName)` - удаляет таблицу;
+* `renameQueue($sourceQueueName, $targetQueueName)` - переименовывает таблицу;
+* `purgeQueue($queueName, Priority $priority = null)` - удаляет записи в таблице (включая мертвые)
+* `getNumberMessages($queueName, Priority $priority = null)` - возвращает количество сообщений доступпніх к прочтению
+(не учитываются мертвые сообщения и сообщения в режиме `in flight`);
+* `addMessage($queueName, $message, Priority $priority = null, $delaySeconds = 0)` - добавляет сообщение в очередь, 
+параметр `$message` может иметь любой тип;
+* `getMessages($queueName, $nbMsg = 1, Priority $priority = null)` - возвращает указаное количество доступных к
+прочтению сообщений. Возвращает массив сообщений. Сообщение в данном случае являет собой массив вида:
+```php
+$message = [
+'id' => '', //int
+'time-in-flight' => time(), //int
+'delayed-until' => time(), //int
+'Body' => '', // mixed
+'priority' => '', //int
+];
+```
+* `deleteMessage($queueName, $message)` - удаляет сообщение из очереди. Параметр `$message` должен иметь тип - 
+```php
+$message = [
+'id' => '', //int
+'time-in-flight' => time(), //int
+'delayed-until' => time(), //int
+'Body' => '', // mixed
+'priority' => '', //int
+];
+```
+* `isEmpty($queueName, Priority $priority = null)` - проверяет есть ли в очереди сообщения 
+(учитываются только НЕ метрвые сообщения)  
+
+### Реализация интерфейса `rollun\callback\Queues\Adapter\DeadMessagesInterface`:
 
 Для работы с мертвыми сообщениями `QueueDbAdapter` реализует методы `getNumberDeadMessages()`, `getDeadMessages()` 
 и `deleteDeadMessages()`.
@@ -22,7 +66,7 @@
 Метод `getDeadMessages()` возвращает найденые мертвые сообщения и тут же их удаляет;
 Метод `deleteDeadMessages()` удаляет указаное количество мертвых сообщений;
 
-Пример:
+### Пример работы адаптера:
 
 ```php
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="test/bootstrap.php" colors="true">
+<phpunit bootstrap="test/bootstrap.php" stopOnFailure="true" colors="true">
     <testsuites>
         <testsuite name="rollun\\test\\callback\\">
             <directory>./test/Callback/</directory>

--- a/src/Callback/src/ConfigProvider.php
+++ b/src/Callback/src/ConfigProvider.php
@@ -40,6 +40,7 @@ use rollun\callback\Queues\DeadLetterQueue;
 use rollun\callback\Queues\Factory\FileAdapterAbstractFactory;
 use rollun\callback\Queues\Factory\QueueClientAbstractFactory;
 use rollun\callback\Queues\Factory\SqsAdapterAbstractFactory;
+use rollun\callback\Queues\Factory\DbAdapterAbstractFactory;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 class ConfigProvider
@@ -55,6 +56,7 @@ class ConfigProvider
                     QueueClientAbstractFactory::class,
                     FileAdapterAbstractFactory::class,
                     SqsAdapterAbstractFactory::class,
+                    DbAdapterAbstractFactory::class,
 
                     // Interrupters
                     HttpAbstractFactory::class,

--- a/src/Callback/src/Queues/Adapter/DbAdapter.php
+++ b/src/Callback/src/Queues/Adapter/DbAdapter.php
@@ -432,7 +432,7 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface, DeadMessage
         $table = new Ddl\CreateTable($tableName);
         $table->addColumn(new Column\Varchar('id', 45));
         $table->addColumn(new Column\Integer('priority_level'));
-        $table->addColumn(new Column\Text('body'));
+        $table->addColumn(new Column\Blob('body'));
         $table->addColumn(new Column\Integer('time_in_flight', true));
         $table->addColumn(new Column\Integer('delayed_until', true));
         $table->addColumn(new Column\Integer('receive_count', true, 0));

--- a/src/Callback/src/Queues/Adapter/DbAdapter.php
+++ b/src/Callback/src/Queues/Adapter/DbAdapter.php
@@ -198,8 +198,9 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
             foreach ($resultSet as $result) {
                 $message = [];
                 $message['id'] = $result->id;
-                $message['body'] = unserialize($result->body);
-                $message['time_in_flight'] = time();
+                $message['time-in-flight'] = time();
+                $message['delayed-until'] = $result->delayed_until;
+                $message['Body'] = unserialize($result->body);
                 $message['priority'] = intval($result->priority_level);
                 $messages[] = $message;
             }

--- a/src/Callback/src/Queues/Adapter/DbAdapter.php
+++ b/src/Callback/src/Queues/Adapter/DbAdapter.php
@@ -349,7 +349,7 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
             ->where(
                 [
                     '(unix_timestamp(now()) - time_in_flight) > ?' => $this->timeInFlight,
-                    'time_in_flight'                                               => null,
+                    'time_in_flight'                               => null,
                 ],
                 Predicate::OP_OR
             );
@@ -394,6 +394,14 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
         }
         if (strpos($queueName, ' ') !== false) {
             throw new InvalidArgumentException('Queue name must not contain white spaces.');
+        }
+
+        if (strlen($queueName) > 64) {
+            throw new InvalidArgumentException('Queue name length must not be grater then 64 symbols.');
+        }
+
+        if (false === preg_match("/^[\w]$/", $queueName, $resss)) {
+            throw new InvalidArgumentException('Queue name must contain symbols like /^[\w]$/ only.');
         }
 
         if ($this->isQueueExists($queueName)) {

--- a/src/Callback/src/Queues/Adapter/DbAdapter.php
+++ b/src/Callback/src/Queues/Adapter/DbAdapter.php
@@ -1,0 +1,473 @@
+<?php
+
+
+namespace rollun\callback\Queues\Adapter;
+
+use ReputationVIP\QueueClient\Adapter\AbstractAdapter;
+use ReputationVIP\QueueClient\Adapter\AdapterInterface;
+use ReputationVIP\QueueClient\Adapter\Exception\InvalidMessageException;
+use ReputationVIP\QueueClient\Adapter\Exception\QueueAccessException;
+use ReputationVIP\QueueClient\PriorityHandler\Priority\Priority;
+use ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface;
+use ReputationVIP\QueueClient\PriorityHandler\StandardPriorityHandler;
+use Exception;
+use InvalidArgumentException;
+use UnexpectedValueException;
+use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\Driver\ResultInterface;
+use Zend\Db\ResultSet\ResultSet;
+use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\Predicate\IsNull;
+use Zend\Db\Sql\Predicate\Predicate;
+use Zend\Db\Sql\Predicate\PredicateSet;
+use Zend\Db\Sql\Predicate\Expression as PredicateExpression;
+use Zend\Db\Metadata\Source\Factory;
+use Zend\Db\Sql\Sql;
+
+class DbAdapter extends AbstractAdapter implements AdapterInterface
+{
+    const MAX_NB_MESSAGES = 10;
+    /** @var Adapter $db */
+    private $db;
+    /** @var int */
+    private $timeInFlight;
+    /** @var PriorityHandlerInterface $priorityHandler */
+    private $priorityHandler;
+
+    /**
+     * @param Adapter                  $db
+     * @param int $timeInFlight
+     * @param PriorityHandlerInterface $priorityHandler
+     *
+     * @throws QueueAccessException
+     */
+    public function __construct(
+        Adapter $db,
+        int $timeInFlight = null,
+        PriorityHandlerInterface $priorityHandler = null
+    ) {
+        if (null === $priorityHandler) {
+            $priorityHandler = new StandardPriorityHandler();
+        }
+
+        $this->db = $db;
+        $this->timeInFlight = $timeInFlight;
+        $this->priorityHandler = $priorityHandler;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function listQueues($prefix = '')
+    {
+        $metadata = Factory::createSourceFromAdapter($this->db);
+        $result = [];
+        foreach ($metadata->getTableNames() as $tableName) {
+            if (!empty($prefix) && !$this->startsWith($tableName, $prefix)) {
+                continue;
+            }
+            $result[] = $tableName;
+        }
+        $result = array_unique($result);
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     * @throws InvalidMessageException
+     * @throws QueueAccessException
+     */
+    public function addMessage($queueName, $message, Priority $priority = null, $delaySeconds = 0)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        if (empty($message)) {
+            throw new InvalidMessageException($message, 'Message empty or not defined.');
+        }
+
+        if (null === $priority) {
+            $priority = $this->priorityHandler->getDefault();
+        }
+
+        if (!$this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                "Queue " . $queueName
+                . " doesn't exist, please create it before using it."
+            );
+        }
+        $tableName = $this->prepareTableName($queueName);
+        $new_message = [
+            'id'             => uniqid(
+                $queueName . $priority->getLevel(),
+                true
+            ),
+            'priority_level' => $priority->getLevel(),
+            'time_in_flight' => null,
+            'delayed_until'  => time() + $delaySeconds,
+            'body'           => serialize($message),
+        ];
+        $sql = new Sql($this->db);
+        $select = $sql->insert()
+            ->into($tableName)
+            ->values($new_message);
+        $statement = $sql->prepareStatementForSqlObject($select);
+        $statement->execute();
+        return $this;
+    }
+
+    /**
+     * @param string $queueName
+     *
+     * @return bool
+     */
+    protected function isQueueExists($queueName)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        $tableName = $this->prepareTableName($queueName);
+        $metadata = Factory::createSourceFromAdapter($this->db);
+        $tableNames = $metadata->getTableNames();
+        return in_array($tableName, $tableNames);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     * @throws QueueAccessException
+     */
+    public function getMessages($queueName, $nbMsg = 1, Priority $priority = null)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        if (!is_numeric($nbMsg)) {
+            throw new InvalidArgumentException('Number of messages must be numeric.');
+        }
+
+        if ($nbMsg <= 0 || $nbMsg > static::MAX_NB_MESSAGES) {
+            throw new InvalidArgumentException('Number of messages is not valid.');
+        }
+
+        if (!$this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                "Queue " . $queueName
+                . " doesn't exist, please create it before using it."
+            );
+        }
+        $tableName = $this->prepareTableName($queueName);
+        $sql = new Sql($this->db);
+        $select = $sql->select()
+            ->from($tableName)
+            ->where(
+                [
+                    new PredicateSet(
+                        [
+                            new PredicateExpression('unix_timestamp(now()) - time_in_flight > ?', $this->timeInFlight),
+                            new IsNull('time_in_flight'),
+                        ],
+                        PredicateSet::COMBINED_BY_OR
+                    ),
+                    new PredicateExpression('delayed_until <= unix_timestamp(now())'),
+                ]
+            );
+        if (null !== $priority) {
+            $select->where(['priority_level' => $priority->getLevel()]);
+        }
+        if ($nbMsg) {
+            $select->limit($nbMsg);
+        }
+        $statement = $sql->prepareStatementForSqlObject($select);
+        $results = $statement->execute();
+        $messages = [];
+        if ($results instanceof ResultInterface && $results->isQueryResult()) {
+            $resultSet = new ResultSet();
+            $resultSet->initialize($results);
+            foreach ($resultSet as $result) {
+                $message = [];
+                $message['id'] = $result->id;
+                $message['body'] = unserialize($result->body);
+                $message['time_in_flight'] = time();
+                $message['priority'] = intval($result->priority_level);
+                $messages[] = $message;
+            }
+        }
+        return $messages;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @param string $queueName
+     * @param array  $message
+     *
+     * @return $this|AdapterInterface
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws InvalidMessageException
+     * @throws QueueAccessException
+     */
+    public function deleteMessage($queueName, $message)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        if (empty($message)) {
+            throw new InvalidMessageException($message, 'Message empty or not defined.');
+        }
+
+        if (!is_array($message)) {
+            throw new InvalidMessageException($message, 'Message must be an array.');
+        }
+
+        if (!isset($message['id'])) {
+            throw new InvalidMessageException($message, 'Message id not found in message.');
+        }
+
+        if (!isset($message['priority'])) {
+            throw new InvalidMessageException($message, 'Message priority not found in message.');
+        }
+
+        $priority = $this->priorityHandler->getPriorityByLevel($message['priority']);
+
+        if (!$this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                "Queue " . $queueName . " doesn't exist, please create it before use it."
+            );
+        }
+
+        $tableName = $this->prepareTableName($queueName);
+        $sql = new Sql($this->db);
+        $delete = $sql->delete($tableName)
+            ->where(['id' => $message['id']]);
+        if (null !== $priority) {
+            $delete->where(['priority_level' => $priority->getLevel()]);
+        }
+        $statement = $sql->prepareStatementForSqlObject($delete);
+        $statement->execute();
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     * @throws QueueAccessException
+     * @throws UnexpectedValueException
+     */
+    public function isEmpty($queueName, Priority $priority = null)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        if (!$this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                "Queue " . $queueName
+                . " doesn't exist, please create it before using it."
+            );
+        }
+        $tableName = $this->prepareTableName($queueName);
+        $sql = new Sql($this->db);
+        $select = $sql->select()
+            ->columns(['total' => new Expression('COUNT(*)')])
+            ->from($tableName);
+        if (null !== $priority) {
+            $select->where(['priority_level' => $priority->getLevel()]);
+        }
+        $statement = $sql->prepareStatementForSqlObject($select);
+        $results = $statement->execute();
+        $count = intval(($results->current())['total']);
+        return $count > 0 ? false : true;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     * @throws QueueAccessException
+     * @throws UnexpectedValueException
+     */
+    public function getNumberMessages($queueName, Priority $priority = null)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        if (!$this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                "Queue " . $queueName
+                . " doesn't exist, please create it before using it."
+            );
+        }
+
+        $tableName = $this->prepareTableName($queueName);
+        $sql = new Sql($this->db);
+        $select = $sql->select()
+            ->columns(['total' => new Expression('COUNT(*)')])
+            ->from($tableName)
+            ->where(
+                [
+                    '(unix_timestamp(now()) - unix_timestamp(time_in_flight)) > ?' => $this->timeInFlight,
+                    'time_in_flight'                                               => null,
+                ],
+                Predicate::OP_OR
+            );
+        if (null !== $priority) {
+            $select->where(['priority_level' => $priority->getLevel()]);
+        }
+        $statement = $sql->prepareStatementForSqlObject($select);
+        $results = $statement->execute();
+        $count = intval(($results->current())['total']);
+        return $count;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function deleteQueue($queueName)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+        $tableName = $this->prepareTableName($queueName);
+        $this->db->query("DROP TABLE IF EXISTS $tableName", Adapter::QUERY_MODE_EXECUTE);
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function createQueue($queueName)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+        if (strpos($queueName, ' ') !== false) {
+            throw new InvalidArgumentException('Queue name must not contain white spaces.');
+        }
+
+        if ($this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                'A queue named ' . $queueName . ' already exist.'
+            );
+        }
+        $tableName = $this->prepareTableName($queueName);
+        $sql = "CREATE TABLE $tableName (
+            `id` VARCHAR(45) NOT NULL, 
+            `priority_level` int(11) NOT NULL, 
+            `body` text COLLATE utf8_unicode_ci,
+            `time_in_flight` int(11) DEFAULT NULL,
+            `delayed_until` int(11) DEFAULT NULL,
+        PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
+        $this->db->query($sql, Adapter::QUERY_MODE_EXECUTE);
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function renameQueue($sourceQueueName, $targetQueueName)
+    {
+        if (empty($sourceQueueName)) {
+            throw new InvalidArgumentException('Source queue name empty or not defined.');
+        }
+
+        if (empty($targetQueueName)) {
+            throw new InvalidArgumentException('Target queue name empty or not defined.');
+        }
+
+        $platform = $this->db->getPlatform();
+        $sourceTableName = $platform->quoteIdentifier($this->prepareTableName($sourceQueueName));
+        $targetTableName = $platform->quoteIdentifier($this->prepareTableName($targetQueueName));
+        $sql = "ALTER TABLE $sourceTableName RENAME TO $targetTableName;";
+        $this->db->query($sql);
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws InvalidArgumentException
+     * @throws QueueAccessException
+     * @throws UnexpectedValueException
+     */
+    public function purgeQueue($queueName, Priority $priority = null)
+    {
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Queue name empty or not defined.');
+        }
+
+        if (null === $priority) {
+            $priorities = $this->priorityHandler->getAll();
+            foreach ($priorities as $priority) {
+                $this->purgeQueue($queueName, $priority);
+            }
+
+            return $this;
+        }
+
+        if (!$this->isQueueExists($queueName)) {
+            throw new QueueAccessException(
+                "Queue " . $queueName
+                . " doesn't exist, please create it before using it."
+            );
+        }
+        $tableName = $this->prepareTableName($queueName);
+        $sql = new Sql($this->db);
+        $select = $sql->delete()
+            ->from($tableName);
+        if (null !== $priority) {
+            $select->where(['priority_level' => $priority->getLevel()]);
+        }
+        $statement = $sql->prepareStatementForSqlObject($select);
+        $statement->execute();
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPriorityHandler()
+    {
+        return $this->priorityHandler;
+    }
+
+    /**
+     * @param $haystack
+     * @param $needle
+     *
+     * @return bool
+     */
+    private function startsWith(string $haystack, string $needle): bool
+    {
+        return $needle === '' || strrpos($haystack, $needle, -strlen($haystack)) !== false;
+    }
+
+    /**
+     * @param string $queueName
+     *
+     * @return string
+     */
+    private function prepareTableName(string $queueName): string
+    {
+        return $queueName;
+    }
+}

--- a/src/Callback/src/Queues/Adapter/DbAdapter.php
+++ b/src/Callback/src/Queues/Adapter/DbAdapter.php
@@ -40,7 +40,7 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
 
     /**
      * @param Adapter                  $db
-     * @param int $timeInFlight
+     * @param int                      $timeInFlight
      * @param PriorityHandlerInterface $priorityHandler
      *
      * @throws QueueAccessException
@@ -114,6 +114,7 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
             'time_in_flight' => null,
             'delayed_until'  => time() + $delaySeconds,
             'body'           => serialize($message),
+            'added_at'       => time(),
         ];
         $sql = new Sql($this->db);
         $select = $sql->insert()
@@ -182,7 +183,8 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
                     ),
                     new PredicateExpression('delayed_until <= unix_timestamp(now())'),
                 ]
-            );
+            )
+            ->order('added_at');
         if (null !== $priority) {
             $select->where(['priority_level' => $priority->getLevel()]);
         }
@@ -382,6 +384,7 @@ class DbAdapter extends AbstractAdapter implements AdapterInterface
         $table->addColumn(new Column\Text('body'));
         $table->addColumn(new Column\Integer('time_in_flight', true));
         $table->addColumn(new Column\Integer('delayed_until', true));
+        $table->addColumn(new Column\Integer('added_at'));
         $table->addConstraint(new Constraint\PrimaryKey('id'));
         $sql = new Sql($this->db);
         $this->db->query(

--- a/src/Callback/src/Queues/Adapter/DeadMessagesInterface.php
+++ b/src/Callback/src/Queues/Adapter/DeadMessagesInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace rollun\callback\Queues\Adapter;
+
+interface DeadMessagesInterface
+{
+
+    /**
+     * @param string $queueName
+     *
+     * @return int
+     */
+    public function getNumberDeadMessages(string $queueName): int;
+
+    /**
+     * @param string $queueName
+     * @param int    $nbMsg
+     *
+     * @return array
+     */
+    public function getDeadMessages(string $queueName, int $nbMsg = 1): array;
+
+    /**
+     * @param string $queueName
+     * @param int    $nbMsg
+     */
+    public function deleteDeadMessages(string $queueName, int $nbMsg = 1);
+
+}

--- a/src/Callback/src/Queues/Factory/DbAdapterAbstractFactory.php
+++ b/src/Callback/src/Queues/Factory/DbAdapterAbstractFactory.php
@@ -10,21 +10,19 @@ namespace rollun\callback\Queues\Factory;
 
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
-use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
 use rollun\callback\Queues\Adapter\DbAdapter;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 
 /**
- * Create instance of FileAdapter
+ * Create instance of DbAdapter
  *
  * Config example:
  *
  * <code>
  *  [
- *      FileAdapterAbstractFactory::class => [
+ *      DbAdapterAbstractFactory::class => [
  *          'requestedServiceName1' => [
  *              'priorityHandler' => 'priorityHandlerServiceName',
- *              'storageDirPath' => 'path/to/directory', // default 'data/queues'
  *              'timeInflight' => 0,
  *          ],
  *          'requestedServiceName2' => [
@@ -34,7 +32,7 @@ use Zend\ServiceManager\Factory\AbstractFactoryInterface;
  *  ]
  * </code>
  *
- * Class FileAdapterAbstractFactory
+ * Class DbAdapterAbstractFactory
  * @package rollun\callback\Queues\Factory
  */
 class DbAdapterAbstractFactory implements AbstractFactoryInterface

--- a/src/Callback/src/Queues/Factory/DbAdapterAbstractFactory.php
+++ b/src/Callback/src/Queues/Factory/DbAdapterAbstractFactory.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright Copyright © 2014 Rollun LC (http://rollun.com/)
+ * @license LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace rollun\callback\Queues\Factory;
+
+use Interop\Container\ContainerInterface;
+use InvalidArgumentException;
+use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
+use rollun\callback\Queues\Adapter\DbAdapter;
+use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+
+/**
+ * Create instance of FileAdapter
+ *
+ * Config example:
+ *
+ * <code>
+ *  [
+ *      FileAdapterAbstractFactory::class => [
+ *          'requestedServiceName1' => [
+ *              'priorityHandler' => 'priorityHandlerServiceName',
+ *              'storageDirPath' => 'path/to/directory', // default 'data/queues'
+ *              'timeInflight' => 0,
+ *          ],
+ *          'requestedServiceName2' => [
+ *
+ *          ],
+ *      ]
+ *  ]
+ * </code>
+ *
+ * Class FileAdapterAbstractFactory
+ * @package rollun\callback\Queues\Factory
+ */
+class DbAdapterAbstractFactory implements AbstractFactoryInterface
+{
+    const KEY_PRIORITY_HANDLER = 'priorityHandler';
+
+    const KEY_TIME_IN_FLIGHT = 'timeInflight';
+
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @return bool
+     */
+    public function canCreate(ContainerInterface $container, $requestedName)
+    {
+        return !empty($container->get('config')[self::class][$requestedName]);
+    }
+
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param array|null $options
+     * @return DbAdapter
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $serviceConfig = $container->get('config')[self::class][$requestedName];
+
+        if (isset($serviceConfig[self::KEY_PRIORITY_HANDLER])) {
+            if (!$container->has($serviceConfig[self::KEY_PRIORITY_HANDLER])) {
+                throw new InvalidArgumentException("Invalid option '" . self::KEY_PRIORITY_HANDLER . "'");
+            } else {
+                $priorityHandler = $container->get($serviceConfig[self::KEY_PRIORITY_HANDLER]);
+            }
+        } else {
+            $priorityHandler = null;
+        }
+
+        $timeInFlight = $serviceConfig[self::KEY_TIME_IN_FLIGHT] ?? 0;
+        $db = $container->get('db');
+        return new DbAdapter($db, $timeInFlight, $priorityHandler);
+    }
+}

--- a/src/Callback/src/Queues/Factory/DbAdapterAbstractFactory.php
+++ b/src/Callback/src/Queues/Factory/DbAdapterAbstractFactory.php
@@ -24,6 +24,7 @@ use Zend\ServiceManager\Factory\AbstractFactoryInterface;
  *          'requestedServiceName1' => [
  *              'priorityHandler' => 'priorityHandlerServiceName',
  *              'timeInflight' => 0,
+ *              'maxReceiveCount' => 0,
  *          ],
  *          'requestedServiceName2' => [
  *
@@ -40,6 +41,8 @@ class DbAdapterAbstractFactory implements AbstractFactoryInterface
     const KEY_PRIORITY_HANDLER = 'priorityHandler';
 
     const KEY_TIME_IN_FLIGHT = 'timeInflight';
+
+    public const KEY_MAX_RECEIVE_COUNT = 'maxReceiveCount';
 
     /**
      * @param ContainerInterface $container
@@ -71,8 +74,10 @@ class DbAdapterAbstractFactory implements AbstractFactoryInterface
             $priorityHandler = null;
         }
 
-        $timeInFlight = $serviceConfig[self::KEY_TIME_IN_FLIGHT] ?? 0;
         $db = $container->get('db');
-        return new DbAdapter($db, $timeInFlight, $priorityHandler);
+        $timeInFlight = $serviceConfig[self::KEY_TIME_IN_FLIGHT] ?? 0;
+        $maxMessageCount = $serviceConfig[self::KEY_MAX_RECEIVE_COUNT] ?? 0;
+
+        return new DbAdapter($db, $timeInFlight, $maxMessageCount, $priorityHandler);
     }
 }

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -1,0 +1,381 @@
+<?php
+
+
+namespace QueueClientTest\Adapter;
+
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReputationVIP\QueueClient\Adapter\Exception\InvalidMessageException;
+use ReputationVIP\QueueClient\Adapter\Exception\QueueAccessException;
+use ReputationVIP\QueueClient\Exception\QueueAliasException;
+use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
+use ReputationVIP\QueueClient\QueueClient;
+use Zend\ServiceManager\ServiceManager;
+
+class DbAdapterTest extends TestCase
+{
+
+    /**
+     * @var ServiceManager
+     */
+    protected $container;
+
+    protected function getContainer(): ServiceManager
+    {
+        if ($this->container === null) {
+            $this->container = require 'config/container.php';
+        }
+
+        return $this->container;
+    }
+
+
+
+    public function getQueueClient(): QueueClient
+    {
+        return $this->getContainer()->build('Application\QueueClient');
+    }
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $queueClient = $this->getQueueClient();
+        foreach ($queueClient->listQueues() as $queue) {
+            $queueClient->deleteQueue($queue);
+        }
+//        foreach ($queueClient->getAliases() as $alias) {
+//            $queueClient->removeAlias($alias);
+//        }
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $queueClient = $this->getQueueClient();
+        foreach ($queueClient->listQueues() as $queue) {
+            $queueClient->deleteQueue($queue);
+        }
+    }
+
+
+    public function testQueueClientCreateQueueWithSpace()
+    {
+        $queueClient = $this->getQueueClient();
+        $this->expectException(InvalidArgumentException::class);
+        $queueClient->createQueue('test Queue One');
+    }
+
+    public function testQueueClientAddMessageWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAlias');
+        $this->assertSame($queueClient, $queueClient->addMessage('queueAlias', 'testMessage'));
+        $queueClient->addAlias('testQueueTwo', 'queueAlias');
+        $this->assertSame($queueClient, $queueClient->addMessage('queueAlias', 'testMessage'));
+    }
+
+    public function testQueueClientAddMessage()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueue');
+        $queueClient->addMessage('testQueue', 'testMessage');
+        $this->assertSame($queueClient, $queueClient->addMessage('testQueue', 'testMessage')); //isTestedInstance()
+    }
+
+    public function testQueueClientAddMessages()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->assertSame($queueClient, $queueClient->addMessages('testQueue', ['testMessageOne', 'testMessageTwo', 'testMessageThree'])); //>isTestedInstance();
+    }
+
+    public function testQueueClientGetMessagesWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAlias');
+        $queueClient->addAlias('testQueueTwo', 'queueAlias');
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->getMessages('queueAlias');
+    }
+
+    public function testQueueClientGetMessages()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->assertIsArray($queueClient->getMessages('testQueue'));
+    }
+
+    public function testQueueClientDeleteMessageWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAlias');
+        $queueClient->addAlias('testQueueTwo', 'queueAlias');
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->deleteMessage('queueAlias', ['testMessage']); // exception
+    }
+
+
+    public function testFileAdapterDeleteMessageWithEmptyQueueName()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->expectException(InvalidArgumentException::class);
+        $queueClient->deleteMessage('', []);
+    }
+
+    public function testFileAdapterDeleteMessageWithNoQueueFile()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $priorityHandler = new ThreeLevelPriorityHandler();
+        $this->assertSame($queueClient, $queueClient->deleteMessage('testQueue', ['id' => 'testQueue-HIGH559f77704e87c5.40358915', 'priority' => $priorityHandler->getHighest()->getLevel()]));
+
+    }
+
+    public function testFileAdapterDeleteMessageWithNoMessage()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->expectException(InvalidMessageException::class);
+        $queueClient->deleteMessage('testQueue', []);
+    }
+
+    public function testFileAdapterDeleteMessageWithNoIdField()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $priorityHandler = new ThreeLevelPriorityHandler();
+        $this->expectException(InvalidMessageException::class);
+        $queueClient->deleteMessage('testQueue', ['priority' => $priorityHandler->getHighest()->getLevel()]);
+    }
+
+    public function testFileAdapterDeleteMessageWithNotPriorityField()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->expectException(InvalidMessageException::class);
+        $queueClient->deleteMessage('testQueue', ['id' => 'testQueue-HIGH559f77704e87c5.40358915']);
+
+    }
+
+    public function testFileAdapterDeleteMessageWithBadMessageType()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->expectException(InvalidMessageException::class);
+        $queueClient->deleteMessage('testQueue', 'message');
+    }
+
+    public function testQueueClientIsEmptyWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAlias');
+        $queueClient->addAlias('testQueueTwo', 'queueAlias');
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->isEmpty('queueAlias');
+    }
+
+    public function testQueueClientIsEmpty()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->assertTrue($queueClient->isEmpty('testQueue'));
+    }
+
+    public function testQueueClientGetNumberMessageWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAlias');
+        $queueClient->addAlias('testQueueTwo', 'queueAlias');
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->getNumberMessages('queueAlias');
+    }
+
+    public function testQueueClientNumberMessage()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $this->assertSame(0, $queueClient->getNumberMessages('testQueue'));
+    }
+
+    public function testQueueClientDeleteQueueWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $queueClient->addAlias('testQueue', 'queueAliasOne');
+        $queueClient->addAlias('testQueue', 'queueAliasTwo');
+        $this->assertSame($queueClient, $queueClient->deleteQueue('testQueue')); // isTestedInstance();
+        $this->assertEmpty($queueClient->getAliases());
+    }
+
+    public function testQueueClientDeleteQueue()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $this->assertSame($queueClient, $queueClient->deleteQueue('testQueue')); //isTestedInstance();
+    }
+
+    public function testQueueClientCreateQueue()
+    {
+        $queueClient = $this->getQueueClient();
+        $this->assertSame($queueClient, $queueClient->createQueue('testQueue')); //isTestedInstance();
+    }
+
+    public function testQueueClientRenameQueueWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueue');
+        $queueClient->addAlias('testQueue', 'queueAliasOne');
+        $queueClient->addAlias('testQueue', 'queueAliasTwo');
+        $this->assertSame($queueClient, $queueClient->renameQueue('testQueue', 'testRenameQueue')); //isTestedInstance();
+        $alases = $queueClient->getAliases();
+        $this->assertIsArray($alases);
+        $this->assertSame(['queueAliasOne' => ['testRenameQueue'], 'queueAliasTwo' => ['testRenameQueue']], $alases);
+    }
+
+    public function testQueueClientRenameQueue()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $this->assertSame($queueClient, $queueClient->renameQueue('testQueue', 'testRenameQueue'));// isTestedInstance();
+    }
+
+    public function testQueueClientPurgeQueueWithAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAlias');
+        $queueClient->addAlias('testQueueTwo', 'queueAlias');
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->purgeQueue('queueAlias');
+    }
+
+    public function testQueueClientPurgeQueue()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueue');
+        $this->assertSame($queueClient, $queueClient->purgeQueue('testQueue')); // isTestedInstance();
+    }
+
+    public function testQueueClientListQueue()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueue');
+        $queueClient->createQueue('testRegexQueue');
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testRegexQueueTwo');
+        $queueClient->createQueue('testQueueTwo');
+        $diff = array_diff(['testQueue', 'testRegexQueue', 'testQueueOne', 'testRegexQueueTwo', 'testQueueTwo'], $queueClient->listQueues());
+        $this->assertEmpty($diff);
+        $diff = array_diff(['testRegexQueue', 'testRegexQueueTwo'], $queueClient->listQueues('/.*Regex.*/'));
+        $this->assertEmpty($diff);
+    }
+
+    public function testQueueClientAddAliasWithEmptyAlias()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueue');
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->addAlias('testQueue', '');
+    }
+
+    public function testQueueClientAddAliasWithEmptyQueueName()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueue');
+
+        $this->expectException(InvalidArgumentException::class);
+        $queueClient->addAlias('', 'queueAlias');
+    }
+
+    public function testQueueClientAddAliasOnUndefinedQueue()
+    {
+        $queueClient = $this->getQueueClient();
+        $this->expectException(QueueAccessException::class);
+        $queueClient->addAlias('testQueue', 'queueAlias');
+    }
+
+    public function testQueueClientAddAlias()
+    {
+        $queueClient = $this->getQueueClient();
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $this->assertSame($queueClient, $queueClient->addAlias('testQueueOne', 'queueAlias'));
+        $this->assertSame($queueClient, $queueClient->addAlias('testQueueTwo', 'queueAlias'));
+        $mockAliases = ['queueAlias' => ['testQueueOne', 'testQueueTwo']];
+        $aliases = $queueClient->getAliases();
+        $this->assertEquals($mockAliases, $aliases);
+    }
+
+    public function testQueueClientRemoveAliasWithUndefinedAlias()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $this->expectException(QueueAliasException::class);
+        $queueClient->RemoveAlias('queueAlias');
+    }
+
+    public function testQueueClientRemoveAlias()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAliasOne');
+        $queueClient->addAlias('testQueueTwo', 'queueAliasTwo');
+        $this->assertSame($queueClient, $queueClient->removeAlias('queueAliasOne'));
+        $this->assertIsArray($queueClient->getAliases());
+        $this->assertEquals(['queueAliasTwo' => ['testQueueTwo']], $queueClient->getAliases());
+
+    }
+
+    public function testQueueClientGetAliases()
+    {
+        $queueClient = $this->getQueueClient();
+
+        $queueClient->createQueue('testQueueOne');
+        $queueClient->createQueue('testQueueTwo');
+        $queueClient->addAlias('testQueueOne', 'queueAliasOne');
+        $queueClient->addAlias('testQueueTwo', 'queueAliasOne');
+        $queueClient->addAlias('testQueueTwo', 'queueAliasTwo');
+        $this->assertIsArray($queueClient->getAliases());
+        $this->assertEquals(['queueAliasOne' => ['testQueueOne', 'testQueueTwo'], 'queueAliasTwo' => ['testQueueTwo']], $queueClient->getAliases());
+    }
+
+    public function testQueueClientGetPriorityHandler()
+    {
+        $queueClient = $this->getQueueClient();
+        $this->assertInstanceOf('ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface', $queueClient->getPriorityHandler());
+    }
+
+}

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -84,21 +84,14 @@ class DbAdapterTest extends TestCase
 
         $messages = $object->getMessages('a', 1);
         $this->assertEquals($messages[0]['Body'], 'a');
-        $object->deleteMessage('a', $messages[0]);
-
         $messages = $object->getMessages('a', 1);
         $this->assertEquals($messages[0]['Body'], 'b');
-        $object->deleteMessage('a', $messages[0]);
-
         $messages = $object->getMessages('a', 1);
         $this->assertEquals($messages[0]['Body'], 'c');
-        $object->deleteMessage('a', $messages[0]);
-
         $messages = $object->getMessages('a', 1);
         $this->assertEquals($messages[0]['Body'], 'd');
-        $object->deleteMessage('a', $messages[0]);
 
-        $this->assertTrue($object->isEmpty('a'));
+        $this->assertFalse($object->isEmpty('a'));
 
         $object->addMessage('a', 'a');
         $object->addMessage('a', 'b');
@@ -153,6 +146,7 @@ class DbAdapterTest extends TestCase
         $object->addMessage('a', 'message');
 
         $this->assertTrue(!empty($object->getMessages('a')));
+        $this->assertTrue(empty($object->getMessages('a')));
         sleep(3);
         $this->assertTrue(!empty($object->getMessages('a')));
     }
@@ -185,9 +179,8 @@ class DbAdapterTest extends TestCase
         $object->createQueue('a');
         $object->addMessage('a', 'message');
         $object->getMessages('a');
-
         $this->assertTrue(!$object->isEmpty('a'));
-        $this->assertFalse(empty($object->getMessages('a')));
+        $this->assertTrue(empty($object->getMessages('a')));
     }
 
     public function testCreateQueueWithSpace()

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -45,6 +45,9 @@ class DbAdapterTest extends TestCase
     protected function dropAllTables() {
         $metadata = Factory::createSourceFromAdapter($this->getDb());
         foreach ($metadata->getTableNames() as $tableName) {
+            if(!$this->startsWith($tableName, DbAdapter::TABLE_NAME_PREFIX)) {
+                continue;
+            }
             $table = new DropTable($tableName);
             $sql = new Sql($this->db);
             $this->db->query(
@@ -52,6 +55,11 @@ class DbAdapterTest extends TestCase
                 Adapter::QUERY_MODE_EXECUTE
             );
         }
+    }
+
+    private function startsWith(string $haystack, string $needle): bool
+    {
+        return $needle === '' || strrpos($haystack, $needle, -strlen($haystack)) !== false;
     }
 
     /**

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -309,6 +309,39 @@ class DbAdapterTest extends TestCase
 
     }
 
+    public function testIsEmptyWithNoMessages()
+    {
+        $object = $this->createObject(5);
+        $object->createQueue('a');
+        $this->assertTrue($object->isEmpty('a'));
+    }
+
+    public function testIsEmptyWithMessages()
+    {
+        $object = $this->createObject(5);
+        $object->createQueue('a');
+        $object->addMessage('a', 'message');
+        $this->assertFalse($object->isEmpty('a'));
+    }
+
+    public function testIsEmptyWithMessagesInFlight()
+    {
+        $object = $this->createObject(5);
+        $object->createQueue('a');
+        $object->addMessage('a', 'message');
+        $object->getMessages('a');
+        $this->assertFalse($object->isEmpty('a'));
+    }
+
+    public function testIsEmptyWithDelayedMessages()
+    {
+        $object = $this->createObject(5);
+        $object->createQueue('a');
+        $object->addMessage('a', 'message', null, 5);
+        $this->assertFalse($object->isEmpty('a'));
+    }
+
+
     public function testGetPriorityHandler()
     {
         $object = $this->createObject(10);

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -72,7 +72,29 @@ class DbAdapterTest extends TestCase
         $this->dropAllTables();
     }
 
-    public function testDeadMessages()
+    public function testSerialize()
+    {
+        $object = $this->createObject(0, 1);
+
+        $serializedObject = serialize($object);
+        $object = unserialize($serializedObject);
+        $object->createQueue('a');
+        $object->addMessage('a', 'message1');
+        $object->addMessage('a', 'message2');
+        $object->addMessage('a', 'message3');
+        $object->addMessage('a', 'message');
+        $object->getMessages('a', 3);
+        sleep(1);
+        $this->assertFalse($object->isEmpty('a'));
+
+        $count = $object->getNumberDeadMessages('a');
+        $deadMessages = $object->getDeadMessages('a', 10);
+
+        $this->assertEquals(3, $count);
+        $this->assertCount(3, $deadMessages);
+    }
+
+        public function testDeadMessages()
     {
         $object = $this->createObject(0, 1);
         $object->createQueue('a');

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -70,6 +70,22 @@ class DbAdapterTest extends TestCase
         $this->assertTrue(in_array('a', $object->listQueues()));
     }
 
+    public function testCreateQueueWithLongName()
+    {
+        $object = $this->createObject(5);
+        $queueName = str_repeat('abracadabra', 100);
+        $this->expectException(InvalidArgumentException::class);
+        $object->createQueue($queueName);
+    }
+
+    public function testCreateQueueWithLongNameNonAscii()
+    {
+        $object = $this->createObject(5);
+        $queueName = str_repeat('Ã', 33);
+        $this->expectException(InvalidArgumentException::class);
+        $object->createQueue($queueName);
+    }
+
     public function testMajor()
     {
         $object = $this->createObject(5);
@@ -105,6 +121,13 @@ class DbAdapterTest extends TestCase
     {
         $object = $this->createObject(5);
         $object->createQueue('â€š"Ã¾');
+        $this->assertTrue(true);
+    }
+
+    public function testCreateQueueWithNameStarsWithNumber()
+    {
+        $object = $this->createObject(5);
+        $object->createQueue('555a');
         $this->assertTrue(true);
     }
 

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -69,6 +69,37 @@ class DbAdapterTest extends TestCase
         $object->createQueue('a');
         $this->assertTrue(in_array('a', $object->listQueues()));
     }
+//
+//    public function testMajor()
+//    {
+//        $object = $this->createObject(5);
+//        $object->createQueue('a');
+//
+//        $object->addMessage('a', 'a');
+//        $object->addMessage('a','b');
+//        $object->addMessage('a','c');
+//        $object->addMessage('a','d');
+//
+//        $this->assertFalse($object->isEmpty('a'));
+//
+//        $messages = $object->getMessages('a', 1);
+//        $this->assertEquals($messages[0]['Body'], 'a');
+//        $messages = $object->getMessages('a', 1);
+//        $this->assertEquals($messages[0]['Body'], 'b');
+//        $messages = $object->getMessages('a', 1);
+//        $this->assertEquals($messages[0]['Body'], 'c');
+//        $messages = $object->getMessages('a', 1);
+//        $this->assertEquals($messages[0]['Body'], 'd');
+//
+//        $this->assertTrue($object->isEmpty('a'));
+//
+//        $object->addMessage('a', 'a');
+//        $object->addMessage('a', 'b');
+//
+//        $object->purgeQueue('a');
+//        $this->assertTrue($object->isEmpty('a'));
+//    }
+
 
     public function testCreateQueueWithBadSymbols()
     {

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -118,7 +118,6 @@ class DbAdapterTest extends TestCase
 
     public function testCreteSameQueueFailed()
     {
-        $this->expectException(\Exception::class);
         $object = $this->createObject(5);
         $object->createQueue('5a');
         $this->assertTrue(in_array('5a', $object->listQueues()));

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -7,6 +7,7 @@ namespace QueueClientTest\Adapter;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use rollun\callback\Queues\Adapter\DbAdapter;
 use ReputationVIP\QueueClient\Adapter\Exception\InvalidMessageException;
 use ReputationVIP\QueueClient\Adapter\Exception\QueueAccessException;
 use ReputationVIP\QueueClient\Exception\QueueAliasException;
@@ -35,7 +36,8 @@ class DbAdapterTest extends TestCase
 
     public function getQueueClient(): QueueClient
     {
-        return $this->getContainer()->build('Application\QueueClient');
+        $db = $this->getContainer()->get('db');
+        return new QueueClient(new DbAdapter($db, 0));
     }
 
     /**

--- a/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
+++ b/test/unit/Callback/Queues/Adapter/DbAdapterTest.php
@@ -69,36 +69,43 @@ class DbAdapterTest extends TestCase
         $object->createQueue('a');
         $this->assertTrue(in_array('a', $object->listQueues()));
     }
-//
-//    public function testMajor()
-//    {
-//        $object = $this->createObject(5);
-//        $object->createQueue('a');
-//
-//        $object->addMessage('a', 'a');
-//        $object->addMessage('a','b');
-//        $object->addMessage('a','c');
-//        $object->addMessage('a','d');
-//
-//        $this->assertFalse($object->isEmpty('a'));
-//
-//        $messages = $object->getMessages('a', 1);
-//        $this->assertEquals($messages[0]['Body'], 'a');
-//        $messages = $object->getMessages('a', 1);
-//        $this->assertEquals($messages[0]['Body'], 'b');
-//        $messages = $object->getMessages('a', 1);
-//        $this->assertEquals($messages[0]['Body'], 'c');
-//        $messages = $object->getMessages('a', 1);
-//        $this->assertEquals($messages[0]['Body'], 'd');
-//
-//        $this->assertTrue($object->isEmpty('a'));
-//
-//        $object->addMessage('a', 'a');
-//        $object->addMessage('a', 'b');
-//
-//        $object->purgeQueue('a');
-//        $this->assertTrue($object->isEmpty('a'));
-//    }
+
+    public function testMajor()
+    {
+        $object = $this->createObject(5);
+        $object->createQueue('a');
+
+        $object->addMessage('a', 'a');
+        $object->addMessage('a','b');
+        $object->addMessage('a','c');
+        $object->addMessage('a','d');
+
+        $this->assertFalse($object->isEmpty('a'));
+
+        $messages = $object->getMessages('a', 1);
+        $this->assertEquals($messages[0]['Body'], 'a');
+        $object->deleteMessage('a', $messages[0]);
+
+        $messages = $object->getMessages('a', 1);
+        $this->assertEquals($messages[0]['Body'], 'b');
+        $object->deleteMessage('a', $messages[0]);
+
+        $messages = $object->getMessages('a', 1);
+        $this->assertEquals($messages[0]['Body'], 'c');
+        $object->deleteMessage('a', $messages[0]);
+
+        $messages = $object->getMessages('a', 1);
+        $this->assertEquals($messages[0]['Body'], 'd');
+        $object->deleteMessage('a', $messages[0]);
+
+        $this->assertTrue($object->isEmpty('a'));
+
+        $object->addMessage('a', 'a');
+        $object->addMessage('a', 'b');
+
+        $object->purgeQueue('a');
+        $this->assertTrue($object->isEmpty('a'));
+    }
 
 
     public function testCreateQueueWithBadSymbols()

--- a/test/unit/Callback/Queues/QueueClientTest.php
+++ b/test/unit/Callback/Queues/QueueClientTest.php
@@ -66,5 +66,6 @@ class QueueClientTest extends TestCase
         );
         $this->assertTrue($this->getContainer()->get('testSqsQueueClient') instanceof QueueClient);
         $this->assertTrue($this->getContainer()->get('testFileQueueClient') instanceof QueueClient);
+        $this->assertTrue($this->getContainer()->get('testDbQueueClient') instanceof QueueClient);
     }
 }


### PR DESCRIPTION
## QueueDbAdapter

`rollun\callback\Queues\Adapter\DbAdapter` - адаптер, реализующий хранение очереди сообщений в БД.
Для работы нужен Db адаптер `Zend\Db\Adapter\Adapter`. `QueueDbAdapter` реализует интерфейсы 
`ReputationVIP\QueueClient\Adapter\AdapterInterface` и `rollun\callback\Queues\Adapter\DeadMessagesInterface`
Первый представляет интерфейс адаптера, который определяет где и каким образом будут храниться сообщения, 
а второй - интерфейс для работы с мертвыми сообщениями.
Для создания `QueueDbAdapter` существует фабрика `DbAdapterAbstractFactory`.

Адаптеру для работы с клиентом очереди можна указывать параметр `timeInFlight`, который указывает на то, 
сколько времени сообщение будет недоступно из очереди, если его не удалить.

Также адаптеру можно передать параметр `maxReceiveCount` (`default=0`) который указывает сколько раз можно 
взять сообщение из очереди до того как оно будет считаться мертвым. 
Мертвые сообщения нельзя достать методом `getMessages()`, нельзя посчитать методом `getNumberMessages()`,
метод `isEmpty()` для очереди, где есть только мертвые сообщения, вернет  `true`.